### PR TITLE
Add support for INT32 with logical type date.

### DIFF
--- a/src/main/java/blue/strategic/parquet/ParquetReader.java
+++ b/src/main/java/blue/strategic/parquet/ParquetReader.java
@@ -13,6 +13,7 @@ import org.apache.parquet.io.DelegatingSeekableInputStream;
 import org.apache.parquet.io.InputFile;
 import org.apache.parquet.io.SeekableInputStream;
 import org.apache.parquet.io.api.GroupConverter;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
 
@@ -20,6 +21,7 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.time.LocalDate;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -156,7 +158,7 @@ public final class ParquetReader<U, S> implements Spliterator<S>, Closeable {
             case FLOAT:
                 return columnReader.getFloat();
             case INT32:
-                return columnReader.getInteger();
+                return readInt32(primitiveType, columnReader);
             case INT64:
                 return columnReader.getLong();
             default:
@@ -166,6 +168,18 @@ public final class ParquetReader<U, S> implements Spliterator<S>, Closeable {
             return null;
         }
     }
+
+    private static Object readInt32(PrimitiveType type, ColumnReader columnReader) {
+        LogicalTypeAnnotation annotation = type.getLogicalTypeAnnotation();
+        int intValue = columnReader.getInteger();
+
+        if (annotation instanceof LogicalTypeAnnotation.DateLogicalTypeAnnotation) {
+            return LocalDate.ofEpochDay(intValue);
+        }
+
+        return intValue;
+    }
+
 
     @Override
     public void close() throws IOException {

--- a/src/main/java/blue/strategic/parquet/ParquetWriter.java
+++ b/src/main/java/blue/strategic/parquet/ParquetWriter.java
@@ -17,7 +17,9 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.time.LocalDate;
 import java.util.Collections;
+import java.util.Date;
 
 public final class ParquetWriter<T> implements Closeable {
 
@@ -145,7 +147,24 @@ public final class ParquetWriter<T> implements Closeable {
             recordConsumer.startField(name, fieldIndex);
 
             switch (type.getPrimitiveTypeName()) {
-            case INT32: recordConsumer.addInteger((int)value); break;
+            case INT32:
+                LogicalTypeAnnotation typeAnnotation = type.getLogicalTypeAnnotation();
+                if (typeAnnotation == LogicalTypeAnnotation.dateType()) {
+                    if (value instanceof Date) {
+                        long unixTimestamp = ((Date) value).getTime();
+                        long daysSinceEpoch = unixTimestamp / 86400000L;
+                        recordConsumer.addInteger((int) daysSinceEpoch);
+                    } else if (value instanceof LocalDate) {
+                        long daysSinceEpoch = ((LocalDate) value).toEpochDay();
+                        recordConsumer.addInteger((int) daysSinceEpoch);
+                    }else {
+                        throw new UnsupportedOperationException(
+                                "Unsupported class for INT32 with logical type date");
+                    }
+                } else {
+                    recordConsumer.addInteger((int) value);
+                }
+                break;
             case INT64: recordConsumer.addLong((long)value); break;
             case DOUBLE: recordConsumer.addDouble((double)value); break;
             case BOOLEAN: recordConsumer.addBoolean((boolean)value); break;

--- a/src/test/java/blue/strategic/parquet/ParquetReadWriteDateTest.java
+++ b/src/test/java/blue/strategic/parquet/ParquetReadWriteDateTest.java
@@ -1,0 +1,120 @@
+package blue.strategic.parquet;
+
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.Types;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class ParquetReadWriteDateTest {
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+
+    Hydrator<Map<String, Object>, Map<String, Object>> HYDRATOR = new Hydrator<>() {
+        @Override
+        public Map<String, Object> start() {
+            return new HashMap<>();
+        }
+
+        @Override
+        public HashMap<String, Object> add(Map<String, Object> target, String heading, Object value) {
+            HashMap<String, Object> r = new HashMap<>(target);
+            r.put(heading, value);
+            return r;
+        }
+
+        @Override
+        public Map<String, Object> finish(Map<String, Object> target) {
+            return target;
+        }
+    };
+
+    @Test
+    public void date_roundtrip() throws IOException {
+        LocalDate date1 = LocalDate.now();
+        LocalDate date2 = LocalDate.of(2026, Month.MAY, 10);
+
+        MessageType schema = new MessageType("test",
+                Types.required(INT32)
+                        .as(LogicalTypeAnnotation.dateType()).named("date"),
+                Types.required(INT64).named("ts"));
+
+        Dehydrator<Object[]> dehydrator = (record, writer) -> {
+            writer.write("date", record[0]);
+            writer.write("ts", record[1]);
+        };
+
+        File file = new File(folder.getRoot(), "date.parquet");
+        try (ParquetWriter<Object[]> writer = ParquetWriter.writeFile(schema, file, dehydrator)) {
+            writer.write(new Object[]{date1, 1000L});
+            writer.write(new Object[]{date2, 2000L});
+        }
+
+
+        try (Stream<Map<String, Object>> s =
+                     ParquetReader.streamContent(file, HydratorSupplier.constantly(HYDRATOR))) {
+            List<Map<String, Object>> rows = s.collect(Collectors.toList());
+
+            assertThat(rows.size(), is(2));
+            assertThat(rows.get(0).get("date"), is(date1));
+            assertThat(rows.get(1).get("date"), is(date2));
+            assertThat(rows.get(0).get("ts"), is(1000L));
+        }
+    }
+
+    /**
+     * You can use a java.util.Date as input. However, the output will always be a LocalDate.
+     */
+    @Test
+    public void date2localDate() throws IOException {
+        Date date1 = new Date(1778371200000L);
+        Date date2 = new Date(1054166400000L);
+
+        LocalDate expectedDate1 = LocalDate.of(2026, Month.MAY, 10);
+        LocalDate expectedDate2 = LocalDate.of(2003, Month.MAY, 29);
+
+        MessageType schema = new MessageType("test",
+                Types.required(INT32)
+                        .as(LogicalTypeAnnotation.dateType()).named("date"),
+                Types.required(INT64).named("ts"));
+
+        Dehydrator<Object[]> dehydrator = (record, writer) -> {
+            writer.write("date", record[0]);
+            writer.write("ts", record[1]);
+        };
+
+        File file = new File(folder.getRoot(), "date.parquet");
+        try (ParquetWriter<Object[]> writer = ParquetWriter.writeFile(schema, file, dehydrator)) {
+            writer.write(new Object[]{date1, 1000L});
+            writer.write(new Object[]{date2, 2000L});
+        }
+
+        try (Stream<Map<String, Object>> s =
+                     ParquetReader.streamContent(file, HydratorSupplier.constantly(HYDRATOR))) {
+            List<Map<String, Object>> rows = s.collect(Collectors.toList());
+            assertThat(rows.size(), is(2));
+            assertThat(rows.get(0).get("date"), is(expectedDate1));
+            assertThat(rows.get(1).get("date"), is(expectedDate2));
+            assertThat(rows.get(0).get("ts"), is(1000L));
+        }
+    }
+}
+


### PR DESCRIPTION
`java.time.LocalDate` and `java.util.Date` can be written into a Parquet file.  In accordance with the Parquet specification for [DATE](https://parquet.apache.org/docs/file-format/types/logicaltypes/#date) the number of days since the Unix epoch will be stored.

When you read a field with type INT32 and logical type date an instance of `java.time.LocalDate` will be returned.

Two tests make sure that the roundtrip for `java.time.LocalDate` as well as the conversion from `java.util.Date` to `java.time.LocalDate` work correctly.

closes #16 